### PR TITLE
Refactor readme and add examples folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,68 @@
-# warsaw
-Warsaw is a JSON Logger and context-based middleware to log HTTP requests (and more) in Golang projects (in [Kiev](https://github.com/blacklane/kiev) format).
+# Warsaw
 
-[![GoDoc](https://godoc.org/github.com/blacklane/warsaw?status.svg)](https://godoc.org/github.com/blacklane/warsaw)
+[![pkg.go.dev](https://img.shields.io/badge/pkg.dev.go-reference-blue)](https://pkg.go.dev/github.com/blacklane/warsaw?tab=overview)
 
-## Development
- 
-The project is standalone [Go Module](https://blog.golang.org/using-go-modules). So everything as for regular gomodule applies, e.g. `go mod tidy`, `go build` and `go list -m all` commands. 
- 
-To run tests of the project use the `go test ./...` command. It will fetch all required dependencies and run all tests.
+`warsaw` is a JSON Logger wrapper around [zerolog](https://github.com/rs/zerolog). Also a http middleware to log HTTP 
+requests (and more) for Go projects.
+The http request log follows the same format and fields as in [Kiev](https://github.com/blacklane/kiev), and you can add
+more as you wish.
+
+You can find the full api reference on [pkg.go.dev](https://pkg.go.dev/github.com/blacklane/warsaw?tab=overview) or
+[GoDoc](https://godoc.org/github.com/blacklane/warsaw)
+
+<!-- TOC depthFrom:1 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
+
+- [Install](#install)
+- [Usage](#usage)
+    - [HTTP requests](#http-requests)
+    - [Standalone logger](#standalone-logger)
+    - [AWS Lambda](#aws-lambda)
+- [Development](#development)
+
+<!-- /TOC -->
+
+## Install
+
+```go
+go get -u github.com/blacklane/warsaw
+```
 
 ## Usage
 
-There is variety of projects you might want to use this lib. 
-
-* [HTTP requests](#http-requests)
-* [Standalone app logger](#standalone-app-logger) (e.g. Kafka consumer project)
-* [AWS Lambda](#aws-lambda)
-
-But it all starts presumably with importing the dependency in your code with `import "github.com/blacklane/warsaw/logger"`. Yet it in details showcased in use-cases below and described in public [API reference](#api-reference-with-examples) below.
+It log to the standard output (`os.Stdout`). All the outputs shown below are pretty printed for convenience, 
+`warsaw`'s output is not pretty printed. All examples are in [examples](examples/)
 
 ### HTTP requests
-Add the middleware to your `http.HandlerFunc` stack. Example:
+
+Add the middleware to your `http.Handler`:
 
 ```go
 package main
 
 import (
-  "fmt"
-  "net/http"
+	"fmt"
+	"net/http"
 
-  "github.com/blacklane/warsaw/logger"
-  "github.com/blacklane/warsaw/request_context"
+	"github.com/blacklane/warsaw/logger"
 )
 
-func PingHandler(w http.ResponseWriter, req *http.Request) {
-  log := logger.Get(req.Context())
+func pingHandler(w http.ResponseWriter, req *http.Request) {
+	log := logger.Get(req.Context())
 
-  log.Event("ping_started").Str("some_field", "value").Int("some_int", 123).Send()
-  fmt.Fprint(w, "ok")
+	log.Event("ping_started").Str("some_field", "value").Int("some_int", 123).Send()
+
+	_, _ = fmt.Fprint(w, "ping")
 }
 
-func main() {
-  loggerMiddleware := logger.NewKievRequestLogger("MyAppName")
-  handlerWithContext := request_context.TrackerMiddleware(loggerMiddleware(PingHandler))
-  routeHandler := request_context.RouteTracker("ping", handlerWithContext)
+func addLogMiddleware() {
+	loggerMiddleware := logger.NewKievRequestLogger("MyAppName")
 
-  http.HandleFunc("/ping", routeHandler)
-  http.ListenAndServe(":8080", nil)
+	http.HandleFunc("/ping", loggerMiddleware(pingHandler))
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		panic(err)
+	}
 }
 ```
-
-
-Lines logged to STDOUT will have the following format:
 
 ```json
 {
@@ -70,7 +81,6 @@ Lines logged to STDOUT will have the following format:
   "some_field": "value",
   "some_int": 123
 }
-
 {
   "level": "info",
   "application": "MyAppName",
@@ -93,121 +103,109 @@ Lines logged to STDOUT will have the following format:
 }
 ```
 
-### Standalone app logger
+### Standalone logger
 
-There are 3 options to use the standalone logger without requestContext. 
-
-#### 1. Via `DefaultLogger` and `logger.Event(name)...` 
-
-Which always prints to the standard output (`os.Stdout`) with module global function: `Event`:
+#### 1. Via `DefaultLogger`
 
 ```go
-package main
-import "github.com/blacklane/warsaw/logger"
-
-func main() {
     logger.Event("myPlainEvent").Msg("log my line")
     logger.Event("myComplexEvent").Str("aString", "field").Int("num", 422).Bool("valid", false).Err(fmt.Errorf("something failed")).Send()
-}
 ```
-
-would log two lines, one in simple mode and second more complex. Without application context but with timestamp fields. Like:
 
 ```json
 {
-    "level":"info", 
-    "message":"log my line",
-    "timestamp":"2020-01-18T18:48:08.708608+01:00",
-    "event":"myPlainEvent"
+  "level": "info",
+  "timestamp": "2020-02-11T16:41:36.690388+01:00",
+  "event": "mySimpleEvent",
+  "message": "log my line"
 }
 {
-    "level":"info", 
-    "num":42,
-    "aString":"field",
-    "valid":false,
-    "timestamp":"2020-01-18T18:48:08.708609+01:00",
-    "event":"myComplexEvent", 
-    "error":"something failed"
+  "level": "info",
+  "timestamp": "2020-02-11T16:41:36.690518+01:00",
+  "event": "myComplexEvent",
+  "aString": "field",
+  "num": 422,
+  "valid": false,
+  "error": "something failed",
+  "message": "foo failed"
 }
 ```  
 
-#### 2. With context-less standalone logger. 
+#### 2. Standalone logger.
 
-But you need to provide the application name and as a return you will get the logger instance + the context.Context that contains the logger if you would like to pass it to some underlying functions. Because plain log instance is not recommended to be passed directly. 
+But you need to provide the application name and as a return you will get the logger instance + the context.Context
+that contains the logger if you would like to pass it to some underlying functions.
 
 ```go
-log, loggerContext := logger.NewStandalone("myAppName")
-log.Event("Log").Msg("me")
+func standaloneLogger() {
+	log, ctx := logger.New(context.TODO(), "myAppName")
+	log.Event("An event").Msg("hello world")
 
-func aFunction(ctx context.Context){
-    theLogger := logger.Get(ctx)
-    theLogger.Event("inFunction").Bool("theLogger", true).Send()
+	useLoggerFromContext(ctx)
 }
 
-aFunction(loggerContext)
+func useLoggerFromContext(ctx context.Context) {
+	log := logger.Get(ctx)
+	log.Event("useLoggerFromContext").Bool("aTruth", true).Msg("hello :)")
+}
 ```
 
 Would log something like this:
 
 ```json
 {
-    "level":"info", 
-    "application": "myAppName",
-    "timestamp":"2020-01-18T18:48:08.708608+01:00",
-    "event":"Log",
-    "message":"me"
+  "level": "info",
+  "application": "myAppName",
+  "timestamp": "2020-02-11T17:42:27.886908+01:00",
+  "event": "An event",
+  "message": "hello world"
 }
 {
-    "level":"info", 
-    "application": "myAppName",
-    "timestamp":"2020-01-18T18:48:08.708609+01:00",
-    "event":"inFunction", 
-    "theLogger": true
+  "level": "info",
+  "application": "myAppName",
+  "timestamp": "2020-02-11T17:55:42.20271+01:00",
+  "event": "loggerFromContext",
+  "aTruth": true,
+  "message": "hello :)"
 }
 ```
 
-#### 3. Using pure logger.New(context, appName)
-
-This way is creating a logger similar way as `NewStandalone` but also registers it in existing context. In certain situations you might have existing context.Context instnce that you're passing already through the app (e.g. when you use http server) and this way you can simply enrich it with the logger.
-
-To create it and use exactly same as the NewStandalone call:
-
-```go
-log, enrichedContext := logger.New(existingContext, "yourAppName")
-```
- 
 ### AWS Lambda
 
-For now there is no extra middleware for lambdaHandlers but it can be used with existing setup and simple instruction that builds the logger and registers it in the handler context.
+For now there is no extra middleware for lambdaHandlers but it can be used with existing setup and simple instruction 
+that builds the logger and registers it in the handler context.
 
 ```go
 package main
 
 import (
-        "fmt"
-        "context"
-        "github.com/aws/aws-lambda-go/lambda"
-        "github.com/blacklane/warsaw/logger"
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-lambda-go/lambda"
+
+	"github.com/blacklane/warsaw/logger"
 )
 
 type MyEvent struct {
-        Name string `json:"name"`
+	Name string `json:"name"`
 }
 
-func otherMethod(ctx context.Context) {
-        log := logger.Get(ctx)
-        log.Event("I'm").Msg("insideMethod")
+func foo(ctx context.Context) {
+	log := logger.Get(ctx)
+	log.Event("I'm").Msg("insideMethod")
 }
 
-func HandleRequest(ctx context.Context, name MyEvent) (string, error) {
-        log, loggerContext := logger.NewLambdaLogger(ctx)
-        log.Event("Called").Str("the_name", name.Name).Send()
-        otherMethod(loggerContext)
-        return fmt.Sprintf("Hello %s!", name.Name ), nil
+func handleRequest(ctx context.Context, name MyEvent) (string, error) {
+	log, ctx := logger.NewLambdaLogger(ctx)
+	log.Event("Called").Str("the_name", name.Name).Send()
+
+	foo(ctx)
+	return fmt.Sprintf("Hello %s!", name.Name), nil
 }
 
 func main() {
-        lambda.Start(HandleRequest)
+	lambda.Start(handleRequest)
 }
 ```
 
@@ -240,221 +238,22 @@ that would log events as follows:
 }
 ```
 
-## API Reference (with examples)
 
-Below you can find most important functions and variables to use. With examples of a use-case. More docs can be found on [GoDoc](https://godoc.org/github.com/blacklane/warsaw). 
+## Contributing
 
-Package `logger`:
+Open an issue, if the change is small, open the PR as well. If the change is big we commend to open the issue to discuss
+it first. 
 
-* [logger.New(ctx context.Context, appName string) (Logger, context.Context)](#loggernewctx-contextcontext-appname-string-logger-contextcontext)
-* [logger.NewStandalone(appName string) (Logger, context.Context)](#loggernewstandaloneappname-string-logger-contextcontext)
-* [logger.DefaultLogger](#loggerdefaultlogger)
-* [logger.LogSink](#loggerlogsink)
-* [logger.Event(name string) *LoggedEvent](#loggereventname-string-loggedevent)
-* [logger.Get(ctx context.Context) Logger](#loggergetctx-contextcontext-logger)
-
-Interface `Logger` from package `logger`:
- 
-* [(Logger)Event(name string) *LoggedEvent](#loggereventname-string-loggedevent)
-* [(Logger)WithScope(map[string]interface{})](#loggerwithscopemapstringinterface)
-* [(Logger) IsDisabled() bool](#loggerisdisabled-bool)
-
-HTTP request handlers:
-
-* [logger.NewKievRequestLogger(appName string) func(http.HandlerFunc) http.HandlerFunc](#loggernewkievrequestloggerappname-string-funchttphandlerfunc-httphandlerfunc) 
-* [logger.LogErrorWithBody(ctx context.Context, err error, errName, responseBody string)](#loggerlogerrorwithbodyctx-contextcontext-err-error-errname-responsebody-string)
-* [logger.NewLambdaLogger(ctx context.Context) (Logger, context.Context)](#loggernewlambdaloggerctx-contextcontext-logger-contextcontext)
-
-
-Package `request_context`:
-
-* [request_context.TrackerMiddleware(next http.HandlerFunc) http.HandlerFunc](#request_contexttrackermiddlewarenext-httphandlerfunc-httphandlerfunc)
-* [request_context.SetTrackerHeaders(ctx, &req.Header)](#request_contextsettrackerheadersctx-reqheader)
-* [request_context.RouteTracker(route string, next http.HandlerFunc) http.HandlerFunc](#request_contextroutetrackerroute-string-next-httphandlerfunc-httphandlerfunc)
-
-Sub-package `contexts` from `request_context`:
-
-* [request_context/contexts.GetRequestID(ctx context.Context) string](#request_contextcontextsgetrequestidctx-contextcontext-string)
-* [request_context/contexts.GetRequestRoute(ctx context.Context) string](#request_contextcontextsgetrequestroutectx-contextcontext-string)
-
---- 
-
-### `logger.New(ctx context.Context, appName string) (Logger, context.Context)`
-
-Creates a new logger and records it in the ctx. Plus sets the application name to appName value.
-
-First returned value is the logger instance and second is enhanced context that includes the logger. If already logger exists in the context it returns it as it is.
-
-### `logger.NewStandalone(appName string) (Logger, context.Context)`
-
-Creates a new logger based on `context.Background()` with provided appName for the logging context. Returns same values as plain `logger.New(...)` [function](#loggernewctx-contextcontext-appname-string-logger-contextcontext).
-
-### `logger.DefaultLogger`
-
-Default logger instance. It is used by `logger.Event(...)` function. It also has the [default](#loggerlogsink) `LogSink` set. Default logger cannot be overwritten and cannot have the scope updated.
-
-### `logger.LogSink`
-
-Allows to setup the logger output. By Default it's set to `os.Stdout`. But can be overwritten before the logger is initialized. The `DefaultLogger` output cannot be changed.     
-
-### `logger.Event(name string) *LoggedEvent`
-
-Logs message to the [DefaultLogger](#loggerdefaultlogger). Can be used directly to quickly log something to default LogSink. It only sets the `event`, `level` and `timestamp` fields. Plus anything set in the chain of methods.
-
-Sample:
+And don't forget:
 
 ```go
-logger.Event("myEventName").Str("some", "data").Int("statusCode", 1234).Send()
+go test ./...
+golint ./...
+go vet ./...
 ```
 
-logs:
+## Licence
 
-```json
-{
-  "level":"info",
-  "timestamp":"2020-01-18T18:50:26.795165+01:00",
-  "event":"myEventName",
-  "some":"data",
-  "statusCode": 1234 
-}
-```
+Copyright 2019 Blacklane
 
-### `logger.Get(ctx context.Context) Logger` 
-
-Returns Logger instance from the argument representing current `context.Context`. Useful to get the logger instance downstream somewhere deep in your app. Then you pass just the context instance all way down and get the `Logger` out using this function.
-
-### `(Logger)Event(name string) *LoggedEvent`
-
-Logs single log line for an event with `name`. It can be called on result of `logger.Get()` method result. The API is same as for `zerolog.Event`. To persist the event you need to call `.Send()` on the returned value.
-
-Sample:
-
-```go
-log := logger.Get(ctx) // to get the Logger instance from context.Context
-log.Event("atlas_request").Int("response_status_code", resp.StatusCode).Dur("elapsed", time.Since(requestStart)).Str("url", fullUrl).Send()
-```
-
-### `(Logger)WithScope(map[string]interface{})`
-
-Updates the context of all logged events with that Logger instance. 
-
-Sample:
-
-```go
-log, _ := logger.NewStandalone("myApp")
-log.WithScope(map[string]interface{}{"important": "yes", "code": 42})
-log.Event("myEvent").Str("crucial", "sure").Send()
-```
-
-logs: 
-
-```json
-{
-    "level":"info", 
-    "application":"myApp",
-    "code":42,
-    "important":"yes",
-    "timestamp":"2020-01-18T18:48:08.708609+01:00",
-    "event":"myEvent", 
-    "crucial":"sure"
-}
-```
-
-So there is the shared scope from `WithScope` and anything defined inline.
-
-### `(Logger)IsDisabled() bool` 
-
-Returns `true` if the logger is disabled or not available in current `context.Context`.
-
-### `logger.NewKievRequestLogger(appName string) func(http.HandlerFunc) http.HandlerFunc` 
-
-Creates a middleware that can wrap `http.HandlerFunc` of your server with logger inside `request.Context()` 
-
-Sample of usage in [HTTP requests use-case](#http-requests).
-
-### `logger.LogErrorWithBody(ctx context.Context, err error, errName, responseBody string)`
-
-When run will update logger context and any subsequent `Logger.Event(name)` will report the error.
-
-⚠️ Keep in mind it won't write anything to the log! It will just remember in logger context that this particular error occurred.
-
-The purpose is to log request error responses. Because such `request_finished` events will be then marked as not-successful.
-
-Sample `http.HandlerFunc` with handling the error and logging it accordingly:
-
-```go
-func MyHandler(w http.ResponseWriter, req *http.Request) {
-	params, err := buildParams(req)
-	if err != nil {
-		responseBody := err.Json()
-		logger.LogErrorWithBody(req.Context(), err, "params.ValidationError", responseBody)
-		w.WriteHeader(422)
-		fmt.Fprint(w, responseBody)
-		return
-	}
-	result := code.Run(req.Context(), params)
-
-	fmt.Fprint(w, result.Json())
-}
-
-func main() {
-    middleware := logger.NewKievRequestLogger("myApp")
-    http.HandlerFunc("/", middleware(MyHandler))
-    http.ListenAndServe(":12345", nil)
-}
-```
-
-### `logger.NewLambdaLogger(ctx context.Context) (Logger, context.Context)`
-
-Returns a logger and enhanced context which is ready to log details of request in JSON responses compatible with Kiev format.
-
-### `request_context.TrackerMiddleware(next http.HandlerFunc) http.HandlerFunc`
-
-This is used inside of `logger.NewKievRequestLogger(...)` so if you use it to get middleware/handlerFunc wrapper you get it already. But if in your use-case for any reasons you just want to extract the Request context details like `RequestId`, `TreePath` and `RequestDepth` but without logging the call in kiev format you should use this TrackerMiddleware.
-
-It will record the `RequestContext` instance in the context of the request + pass the RequestId to the response Headers accordingly. This makes sense in for example `PingHandler` use-case. When logging every ping/health-check is an overkill but you might be interested in having the correlation ID like `RequestId` available in the call in case of an issue.
-
-### `request_context.SetTrackerHeaders(ctx, &req.Header)`
-
-When you recorded the `RequestContext` with this method you can pass it to downstream net/http.Request calls. 
-
-Sample:
-
-```go
-req, err := http.NewRequest("GET", fullUrl, postBody)
-request_context.SetTrackerHeaders(ctx, &req.Header)
-
-httpClient := &http.Client{}
-resp, err := httpClient.Do(req) // the called fullUrl will be done with all correct headers passed from the originated request 
-```
-
-### `request_context.RouteTracker(route string, next http.HandlerFunc) http.HandlerFunc`
-
-To add extra context related to route name behind particular `http.HandlerFunc` you can wrap your call with this extra middleware and specify in first argument the name of the route. It will then be reported with every line of the logged events.  
-
-Sample of use of `RouteTracker` and `TrackerHandler` together but without the `NewKievRequestLogger`:
-
-```go
-func pingHandler(w http.ResponseWriter, req *http.Request) {
-	fmt.Fprint(w, "ok")
-}
-
-func main() {
-    route("/ping", pingHandler)
-    http.ListenAndServe(":12345", nil)
-}
-
-func route(routeName string, handler http.HandlerFunc) {
-	handlerWithContext := request_context.TrackerMiddleware(handler)
-	routeHandler := request_context.RouteTracker(routeName, handlerWithContext)
-	http.HandleFunc(path, routeHandler)
-}
-```  
-
-### `request_context/contexts.GetRequestID(ctx context.Context) string`
-
-Use this method if you need to access the `RequestId` recorded using `TrackingMiddleware` directly in your code. 
-
-### `request_context/contexts.GetRequestRoute(ctx context.Context) string`
- 
- Use this method if you need to access the `RequestRoute` recorded using `RouteTracker` directly in your code.
+Licensed under [MIT License](LICENSE.md)

--- a/examples/aws_lambda.go
+++ b/examples/aws_lambda.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-lambda-go/lambda"
+
+	"github.com/blacklane/warsaw/logger"
+)
+
+type MyEvent struct {
+	Name string `json:"name"`
+}
+
+func foo(ctx context.Context) {
+	log := logger.Get(ctx)
+	log.Event("I'm").Msg("insideMethod")
+}
+
+func handleRequest(ctx context.Context, name MyEvent) (string, error) {
+	log, ctx := logger.NewLambdaLogger(ctx)
+	log.Event("Called").Str("the_name", name.Name).Send()
+
+	foo(ctx)
+	return fmt.Sprintf("Hello %s!", name.Name), nil
+}
+
+func main() {
+	lambda.Start(handleRequest)
+}

--- a/examples/http_request.go
+++ b/examples/http_request.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/blacklane/warsaw/logger"
+)
+
+func pingHandler(w http.ResponseWriter, req *http.Request) {
+	log := logger.Get(req.Context())
+
+	log.Event("ping_started").Str("some_field", "value").Int("some_int", 123).Send()
+
+	_, _ = fmt.Fprint(w, "ping")
+}
+
+func addLogMiddleware() {
+	loggerMiddleware := logger.NewKievRequestLogger("MyAppName")
+
+	http.HandleFunc("/ping", loggerMiddleware(pingHandler))
+	if err := http.ListenAndServe(":8080", nil); err != nil {
+		panic(err)
+	}
+}

--- a/examples/standalone.go
+++ b/examples/standalone.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"errors"
+
+	"github.com/blacklane/warsaw/logger"
+)
+
+func defaultLogger() {
+	logger.Event("mySimpleEvent").
+		Msg("log my line")
+
+	logger.Event("myComplexEvent").
+		Str("aString", "field").
+		Int("num", 422).
+		Bool("valid", false).
+		Err(errors.New("something failed")).
+		Msg("foo failed")
+}
+
+func standaloneLogger() {
+	log, ctx := logger.New(context.TODO(), "myAppName")
+	log.Event("An event").Msg("hello world")
+
+	useLoggerFromContext(ctx)
+}
+
+func useLoggerFromContext(ctx context.Context) {
+	log := logger.Get(ctx)
+	log.Event("useLoggerFromContext").Bool("aTruth", true).Msg("hello :)")
+}

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,13 @@ github.com/aws/aws-lambda-go v1.13.3 h1:SuCy7H3NLyp+1Mrfp+m80jcbi9KYWAs9/BXwppwR
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.16.0 h1:AaELmZdcJHT8m6oZ5py4213cdFK8XGXkB3dFdAQ+P7Q=
@@ -14,6 +17,7 @@ github.com/rs/zerolog v1.16.0/go.mod h1:9nvC1axdVrAHcu/s9taAVfBuIdTZLVQmKQyvrUjF
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/zenazn/goji v0.9.0/go.mod h1:7S9M489iMyHBNxwZnk9/EHS098H4/F6TATF2mIxtB1Q=
@@ -24,5 +28,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
* add examples folder with the examples shown in the readme
* On README.md:
  * add table of contents
  * rewrite description
  * use pkg.go.dev instead of godoc.org
  * adjust the examples
  * add contributing and license sections
  * remove API reference section