### PR TITLE
[OS-2006] allow logging to log level error

### DIFF
--- a/examples/standalone.go
+++ b/examples/standalone.go
@@ -17,11 +17,15 @@ func defaultLogger() {
 		Bool("valid", false).
 		Err(errors.New("something failed")).
 		Msg("foo failed")
+
+	logger.ErrorEvent("An event", errors.New("error")).
+		Msg("Failed to create something")
 }
 
 func standaloneLogger() {
 	log, ctx := logger.New(context.TODO(), "myAppName")
 	log.Event("An event").Msg("hello world")
+	log.ErrorEvent("An event", errors.New("error")).Msg("Failed to create something")
 
 	useLoggerFromContext(ctx)
 }
@@ -29,4 +33,9 @@ func standaloneLogger() {
 func useLoggerFromContext(ctx context.Context) {
 	log := logger.Get(ctx)
 	log.Event("useLoggerFromContext").Bool("aTruth", true).Msg("hello :)")
+}
+
+func main() {
+	standaloneLogger()
+	defaultLogger()
 }

--- a/examples/standalone.go
+++ b/examples/standalone.go
@@ -18,14 +18,14 @@ func defaultLogger() {
 		Err(errors.New("something failed")).
 		Msg("foo failed")
 
-	logger.ErrorEvent("An event", errors.New("error")).
+	logger.Error("An event", errors.New("error")).
 		Msg("Failed to create something")
 }
 
 func standaloneLogger() {
 	log, ctx := logger.New(context.TODO(), "myAppName")
 	log.Event("An event").Msg("hello world")
-	log.ErrorEvent("An event", errors.New("error")).Msg("Failed to create something")
+	log.Error("An event", errors.New("error")).Msg("Failed to create something")
 
 	useLoggerFromContext(ctx)
 }

--- a/logger/internal.go
+++ b/logger/internal.go
@@ -13,6 +13,7 @@ import (
 // internalLogger shares interface of the logger and encapsulates the internal zerolog used for it's implementation
 type internalLogger interface {
 	Info() *LoggedEvent
+	Err(err error) *LoggedEvent
 	WithContext(context.Context) context.Context
 	UpdateContext(func(Context) Context)
 	GetLevel() Level

--- a/logger/log_event.go
+++ b/logger/log_event.go
@@ -6,6 +6,7 @@ import (
 
 type eventLogger interface {
 	Event(name string) *LoggedEvent
+	ErrorEvent(name string, err error) *LoggedEvent
 }
 
 // Event logs single log line for an event with `name`. It can be called on result of `logger.Get()` method result.
@@ -17,7 +18,18 @@ func (logger logger) Event(name string) *LoggedEvent {
 	return logger.log.Info().Timestamp().Str(kiev_fields.Event, name)
 }
 
+// ErrorEvent logs single log line for an event with the log level set to error. It passes the `err` parameter in to
+// zerolog, which prints it as part of the log line.
+func (logger logger) ErrorEvent(name string, err error) *LoggedEvent {
+	return logger.log.Err(err).Timestamp().Str(kiev_fields.Event, name)
+}
+
 // Event package function logs message with DefaultLogger
 func Event(name string) *LoggedEvent {
 	return DefaultLogger.Event(name)
+}
+
+// Event package function logs message with DefaultLogger on loglevel error
+func ErrorEvent(name string, err error) *LoggedEvent {
+	return DefaultLogger.ErrorEvent(name, err)
 }

--- a/logger/log_event.go
+++ b/logger/log_event.go
@@ -6,7 +6,7 @@ import (
 
 type eventLogger interface {
 	Event(name string) *LoggedEvent
-	ErrorEvent(name string, err error) *LoggedEvent
+	Error(name string, err error) *LoggedEvent
 }
 
 // Event logs single log line for an event with `name`. It can be called on result of `logger.Get()` method result.
@@ -18,9 +18,9 @@ func (logger logger) Event(name string) *LoggedEvent {
 	return logger.log.Info().Timestamp().Str(kiev_fields.Event, name)
 }
 
-// ErrorEvent logs single log line for an event with the log level set to error. It passes the `err` parameter in to
+// Error logs single log line for an event with the log level set to error. It passes the `err` parameter in to
 // zerolog, which prints it as part of the log line.
-func (logger logger) ErrorEvent(name string, err error) *LoggedEvent {
+func (logger logger) Error(name string, err error) *LoggedEvent {
 	return logger.log.Err(err).Timestamp().Str(kiev_fields.Event, name)
 }
 
@@ -30,6 +30,6 @@ func Event(name string) *LoggedEvent {
 }
 
 // Event package function logs message with DefaultLogger on loglevel error
-func ErrorEvent(name string, err error) *LoggedEvent {
-	return DefaultLogger.ErrorEvent(name, err)
+func Error(name string, err error) *LoggedEvent {
+	return DefaultLogger.Error(name, err)
 }


### PR DESCRIPTION
We need to log things to log level error with the warsaw logger. This is currently not possible when using the `log.Event(...)` function, as there is no method to set the log level. I added a new `log.ErrorEvent(...)` function to resolve this. Also adjusted the example.

JIRA: https://blacklane.atlassian.net/browse/OS-2006

Output from standalone logger example:
```
{"level":"info","application":"myAppName","timestamp":"2020-03-19T13:53:45.360598+01:00","event":"An event","message":"hello world"}
{"level":"error","application":"myAppName","error":"Error!","timestamp":"2020-03-19T13:53:45.36086+01:00","event":"An event","message":"Failed to create something"}
{"level":"info","application":"myAppName","timestamp":"2020-03-19T13:53:45.360864+01:00","event":"useLoggerFromContext","aTruth":true,"message":"hello :)"}
{"level":"info","timestamp":"2020-03-19T13:53:45.360867+01:00","event":"mySimpleEvent","message":"log my line"}
{"level":"info","timestamp":"2020-03-19T13:53:45.36087+01:00","event":"myComplexEvent","aString":"field","num":422,"valid":false,"error":"something failed","message":"foo failed"}
{"level":"error","error":"Error!","timestamp":"2020-03-19T13:53:45.360876+01:00","event":"An event","message":"Failed to create something"}
```